### PR TITLE
:building_construction: Use options for newlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,15 @@ jobs:
       - name: 📦 Create Conan Package
         run: conan create prebuilt --version=${{ inputs.version }}
 
-      - name: 🏗️ Build Demo Package
+      - name: 🏗️ Build Demos Conan Package
+        if: ${{ runner.os != 'Windows' }}
         working-directory: prebuilt/demo
-        run: conan build . -o "*:version=${{ inputs.version }}" -pr profile
+        run: VERBOSE=1 conan build . -pr profile -s compiler.version="${{ inputs.version }}"
+
+      - name: 🏗️ Build Demos Conan Package
+        if: ${{ runner.os == 'Windows' }}
+        working-directory: prebuilt/demo
+        run: conan build . -pr profile -s compiler.version="${{ inputs.version }}"
 
       - name: 📡 Sign into JFrog Artifactory
         if: ${{ github.ref == 'refs/heads/main' && runner.os != 'Windows' }}

--- a/prebuilt/conanfile.py
+++ b/prebuilt/conanfile.py
@@ -1,6 +1,5 @@
 from conan import ConanFile
 from conan.tools.files import get, copy
-from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=2.0.6"
@@ -24,15 +23,6 @@ class PrebuiltPicolibc(ConanFile):
 
     def package_id(self):
         self.info.clear()
-
-    def validate(self):
-        if (
-            self.settings.compiler == "gcc" and
-            self.settings.os == "baremetal" and
-            self.settings.compiler.get_safe("newlib") != "picolibc"
-        ):
-            raise ConanInvalidConfiguration(
-                "settings.compiler.newlib must be set to picolibc to use this package!")
 
     def build(self):
         get(self,
@@ -67,15 +57,11 @@ class PrebuiltPicolibc(ConanFile):
         prefix = os.path.join(self.package_folder, 'arm-none-eabi')
         picolibcpp_specs = os.path.join(self.package_folder, specs_path)
 
-        newlib = self.settings.compiler.get_safe("newlib")
-        if newlib == "picolibc":
-            self.cpp_info.exelinkflags = [
-                f"-specs={picolibcpp_specs}",
-                f"--picolibc-prefix={prefix}",
-                f"-oslib={str(self.options.crt0)}",
-            ]
-            self.output.info(f"link flags: {self.cpp_info.exelinkflags}")
-            self.output.info(f"crt0: {str(self.options.crt0)}")
-        else:
-            self.output.warning(
-                f"newlib set to: '{newlib}', compiler flags not used!")
+        self.cpp_info.exelinkflags = [
+            f"-specs={picolibcpp_specs}",
+            f"--picolibc-prefix={prefix}",
+            f"-oslib={str(self.options.crt0)}",
+        ]
+
+        self.output.info(f"link flags: {self.cpp_info.exelinkflags}")
+        self.output.info(f"crt0: {str(self.options.crt0)}")

--- a/prebuilt/demo/conanfile.py
+++ b/prebuilt/demo/conanfile.py
@@ -5,19 +5,15 @@ from conan.tools.cmake import CMake, cmake_layout
 class Demo(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualBuildEnv"
-    options = {
-        "version": [
-            "12.2",
-            "12.3",
-        ]
-    }
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
-        self.tool_requires(f"arm-gnu-toolchain/{self.options.version}")
+        self.tool_requires(
+            f"arm-gnu-toolchain/{self.settings.compiler.version}",
+            options={"custom_libc": True})
 
     def requirements(self):
-        self.requires(f"prebuilt-picolibc/{self.options.version}")
+        self.requires(f"prebuilt-picolibc/{self.settings.compiler.version}")
 
     def layout(self):
         cmake_layout(self)

--- a/prebuilt/demo/profile
+++ b/prebuilt/demo/profile
@@ -3,7 +3,6 @@ build_type=MinSizeRel
 compiler=gcc
 compiler.cppstd=20
 compiler.libcxx=libstdc++
-compiler.newlib=picolibc
 compiler.version=12.2
 arch=cortex-m4f
 os=baremetal


### PR DESCRIPTION
Using newlib as a compatibility setting is incorrect as the choice of newlib libc library implementation is a link time choice and does not affect codegen or ABI.